### PR TITLE
Feature/open server auth api

### DIFF
--- a/smpp/server.go
+++ b/smpp/server.go
@@ -31,10 +31,15 @@ const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
 // that is called when client PDU messages arrive.
 type RequestHandlerFunc func(Session, pdu.Body)
 
+// AuthRequestHandlerFunc is the signature of a function passed to Server instances,
+// that is called when a client is trying to bind to the server.
+type AuthRequestHandlerFunc func(Session, pdu.Body) error
+
 type Server interface {
 	Addr() string
 	Close()
 	Handle(id pdu.ID, h RequestHandlerFunc)
+	HandleAuth(id pdu.ID, h AuthRequestHandlerFunc)
 	Start()
 	Serve()
 	Session(id string) Session
@@ -50,6 +55,7 @@ type server struct {
 	TLS      *tls.Config
 
 	m  map[pdu.ID]RequestHandlerFunc
+	a  map[pdu.ID]AuthRequestHandlerFunc
 	s  map[string]Session
 	mu sync.Mutex
 	l  net.Listener
@@ -114,6 +120,7 @@ func NewUnstartedServer(user, password string, listener net.Listener) Server {
 		User:   user,
 		Passwd: password,
 		m:      map[pdu.ID]RequestHandlerFunc{},
+		a:      map[pdu.ID]AuthRequestHandlerFunc{},
 		s:      map[string]Session{},
 		l:      listener,
 	}
@@ -178,12 +185,7 @@ func (srv *server) Serve() {
 // handle new clients.
 func (srv *server) handle(c *conn) {
 	defer c.Close()
-	if err := srv.auth(c); err != nil {
-		if err != io.EOF {
-			log.Println("Server auth failed:", err)
-		}
-		return
-	}
+
 	// Use connSwitch to have synced read/write
 	s := &session{conn: &connSwitch{}}
 	s.conn.Set(c)
@@ -191,6 +193,12 @@ func (srv *server) handle(c *conn) {
 	srv.mu.Lock()
 	srv.s[s.id] = s
 	srv.mu.Unlock()
+
+	if err := srv.auth(c, s); err != nil {
+		log.Println("Server auth failed:", err)
+		return
+	}
+
 	for {
 		p, err := s.Read()
 		if err != nil {
@@ -215,12 +223,31 @@ func (srv *server) Handle(id pdu.ID, h RequestHandlerFunc) {
 	srv.m[id] = h
 }
 
-// auth authenticate new clients.
-func (srv *server) auth(c *conn) error {
+func (srv *server) HandleAuth(id pdu.ID, h AuthRequestHandlerFunc) {
+	srv.a[id] = h
+}
+
+func (srv *server) auth(c *conn, s Session) error {
 	p, err := c.Read()
 	if err != nil {
 		return err
 	}
+
+	// Read the bind PDU and if there are any handlers set, use them,
+	// if not perform the default auth
+	if h, ok := srv.a[p.Header().ID]; ok {
+		return h(s, p)
+	}
+
+	resp, err := srv.defaultAuth(p)
+	if err != nil {
+		return err
+	}
+	return c.Write(resp)
+}
+
+// auth authenticate new clients.
+func (srv *server) defaultAuth(p pdu.Body) (pdu.Body, error) {
 	var resp pdu.Body
 	switch p.Header().ID {
 	case pdu.BindTransmitterID:
@@ -230,25 +257,22 @@ func (srv *server) auth(c *conn) error {
 	case pdu.BindTransceiverID:
 		resp = pdu.NewBindTransceiverResp()
 	default:
-		return errors.New("unexpected pdu, want bind")
+		return nil, errors.New("unexpected pdu, want bind")
 	}
 	f := p.Fields()
 	user := f[pdufield.SystemID]
 	passwd := f[pdufield.Password]
 	if user == nil || passwd == nil {
-		return errors.New("malformed pdu, missing system_id/password")
+		return nil, errors.New("malformed pdu, missing system_id/password")
 	}
 	if user.String() != srv.User {
-		return errors.New("invalid user")
+		return nil, errors.New("invalid user")
 	}
 	if passwd.String() != srv.Passwd {
-		return errors.New("invalid passwd")
+		return nil, errors.New("invalid passwd")
 	}
 	resp.Fields().Set(pdufield.SystemID, DefaultSystemID)
-	if err = c.Write(resp); err != nil {
-		return err
-	}
-	return nil
+	return resp, nil
 }
 
 // EchoHandler is the default Server RequestHandlerFunc, and echoes back

--- a/smpp/server_test.go
+++ b/smpp/server_test.go
@@ -6,7 +6,9 @@ package smpp
 
 import (
 	"bytes"
+	"errors"
 	"net"
+	"os"
 	"testing"
 
 	"github.com/veoo/go-smpp/smpp/pdu"
@@ -15,19 +17,40 @@ import (
 )
 
 var (
-	s    Server
-	pass = "secret"
-	user = "client"
-	port = 0 // any port
+	s          Server
+	pass       = "secret"
+	user       = "client"
+	customUser = "customUser"
+	customPass = "customPass"
+	port       = 0 // any port
 )
+
+func BindTransceiverHandler(s Session, m pdu.Body) error {
+	f := m.Fields()
+	user := f[pdufield.SystemID]
+	passwd := f[pdufield.Password]
+	if user == nil || passwd == nil {
+		return errors.New("malformed pdu, missing system_id/password")
+	}
+	if user.String() != customUser {
+		return errors.New("invalid user")
+	}
+	if passwd.String() != customPass {
+		return errors.New("invalid passwd")
+	}
+	resp := pdu.NewBindTransceiverResp()
+	resp.Fields().Set(pdufield.SystemID, DefaultSystemID)
+	return s.Write(resp)
+}
 
 func TestMain(m *testing.M) {
 	s = NewServer(user, pass, NewLocalListener(port))
 	s.Handle(pdu.BindTransmitterID, EchoHandler)
 	s.Handle(pdu.SubmitSMID, EchoHandler)
+	s.HandleAuth(pdu.BindTransceiverID, BindTransceiverHandler)
 
 	defer s.Close()
-	m.Run()
+	os.Exit(m.Run())
 }
 
 func TestServer(t *testing.T) {
@@ -86,5 +109,61 @@ func TestServer(t *testing.T) {
 			t.Fatalf("unexpected field data: want %#v, have %#v",
 				v, vv)
 		}
+	}
+}
+
+func TestIncorrectAuth(t *testing.T) {
+	c, err := net.Dial("tcp", s.Addr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	rw := newConn(c)
+	// bind
+	p := pdu.NewBindTransceiver()
+	f := p.Fields()
+
+	// Test with incorrect credentials that would work with defaultAuth()
+	f.Set(pdufield.SystemID, user)
+	f.Set(pdufield.Password, pass)
+	f.Set(pdufield.InterfaceVersion, 0x34)
+	if err = rw.Write(p); err != nil {
+		t.Fatal(err)
+	}
+	// bind resp
+	resp, err := rw.Read()
+	if err == nil {
+		t.Fatalf("authenticated with incorrect credentials: %#v", resp)
+	}
+}
+
+func TestCorrectAuth(t *testing.T) {
+	c, err := net.Dial("tcp", s.Addr())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+	rw := newConn(c)
+	// bind
+	p := pdu.NewBindTransceiver()
+	f := p.Fields()
+
+	// Test with correct credentials that BindTransceiverHandler accepts
+	f.Set(pdufield.SystemID, customUser)
+	f.Set(pdufield.Password, customPass)
+	if err := rw.Write(p); err != nil {
+		t.Fatal(err)
+	}
+	// bind resp
+	resp, err := rw.Read()
+	if err != nil {
+		t.Fatalf("failed to read resp: %v", err)
+	}
+	id, ok := resp.Fields()[pdufield.SystemID]
+	if !ok {
+		t.Fatalf("missing system_id field: %#v", resp)
+	}
+	if id.String() != "sys_id" {
+		t.Fatalf("unexpected system_id: want sys_id, have %q", id)
 	}
 }


### PR DESCRIPTION
Since the Binding (authenticating an incoming connection) was done inside of server, it was not customizable, so the AuthHandlers (BindTransceiver, BindTransmitter, BindReceiver) are now also available in the API. When a new connection is made, the server will check if the requested Bind is saved in the AuthHandlers. If it is, it will execute it and check for any errors returned by the handler. If it is not, it will execute the default authentication.
